### PR TITLE
Adjust map labels and title spacing

### DIFF
--- a/TWO_Script/two_map.py
+++ b/TWO_Script/two_map.py
@@ -59,14 +59,14 @@ def setup_basemap(ax, basin):
     for lon in xticks:
         hemi = "W" if lon < 0 else ("E" if lon > 0 else "")
         pos_x = (lon - xmin) / x_range
-        halo(pos_x, 1.01, f"{abs(lon):.0f}°{hemi}", ha="center", va="bottom")
+        halo(pos_x, 0.995, f"{abs(lon):.0f}°{hemi}", ha="center", va="top")
 
     # latitude labels positioned at their actual locations
     y_range = ymax - ymin if ymax != ymin else 1
     for lat in yticks:
         hemi = "S" if lat < 0 else ("N" if lat > 0 else "")
         pos_y = (lat - ymin) / y_range
-        halo(1.02, pos_y, f"{abs(lat):.0f}°{hemi}", ha="left", va="center")
+        halo(0.995, pos_y, f"{abs(lat):.0f}°{hemi}", ha="right", va="center")
 
 
 def draw_two_polygons(ax, two):

--- a/TWO_Script/two_plot.py
+++ b/TWO_Script/two_plot.py
@@ -32,17 +32,27 @@ def build_outlook(basin: str, label: str, prefix: str,
     draw_legend(ax, basin, issue_dt)
     draw_timestamp(ax, basin, issue_dt)
 
-    fig.subplots_adjust(left=0.005, right=0.995, bottom=0.02, top=0.90)
+    fig.subplots_adjust(left=0.005, right=0.995, bottom=0.02, top=0.92)
 
     # --- keep the map from autoscaling when we add polygons -------------
     ax.set_extent(DEFAULT_EXTENT[basin], crs=ccrs.PlateCarree())
     ax.set_autoscale_on(False)        # turn autoscaling off
     ax.apply_aspect()                 # re-align ticks / gridlines
     # -------------------------------------------------------------------
-    fig.suptitle(f"Combined Graphical Tropical Weather Outlook for {label}",
-                 fontsize=20, weight="bold", y=0.955)
-    fig.text(0.5, 0.905, "Creado por Huracanes Caribe - www.huracanescaribe.com -",
-             ha="center", va="top", fontsize=18)
+    fig.suptitle(
+        f"Combined Graphical Tropical Weather Outlook for {label}",
+        fontsize=20,
+        weight="bold",
+        y=0.955,
+    )
+    fig.text(
+        0.5,
+        0.93,
+        "Creado por Huracanes Caribe - www.huracanescaribe.com -",
+        ha="center",
+        va="top",
+        fontsize=18,
+    )
 
     # Footer
     stamp = issue_dt.strftime("%d %b %Y %H:%M UTC")


### PR DESCRIPTION
## Summary
- keep latitude/longitude labels inside the map
- tighten top spacing so title and subtitle sit closer to map

## Testing
- `python3 TWO_Script/main.py --basin AL EP --timestamp 2025-07-02T17:22:00Z` *(fails: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_6865d24034d4832ba548eea2c016c23b