### PR TITLE
Refactor arrow drawing

### DIFF
--- a/TWO_Script/requirements.txt
+++ b/TWO_Script/requirements.txt
@@ -3,16 +3,12 @@
 # Core libraries
 matplotlib>=3.7
 numpy>=1.23
-pillow>=9.5
 requests>=2.31
 
 # Geospatial stack
 geopandas>=0.13
 shapely>=2.0
 cartopy>=0.21
-
-# Cairo-based arrow rendering
-cairocffi>=1.5
 
 # Timezone support (for Python < 3.9 use backports.zoneinfo)
 # Python 3.9+ includes zoneinfo in stdlib


### PR DESCRIPTION
## Summary
- replace custom Cairo+PIL arrow with Matplotlib arrow
- drop Cairo and Pillow dependencies
- compute arrow target from nearest polygon boundary
- add adjustable arrow scale

## Testing
- `python -m py_compile TWO_Script/two_map.py TWO_Script/two_plot.py TWO_Script/two_data.py`


------
https://chatgpt.com/codex/tasks/task_e_6865f98e626c832ba9ecf3b9c83a3d70