### PR TITLE
Use consistent issuance timestamp from XML

### DIFF
--- a/TWO_Script/main.py
+++ b/TWO_Script/main.py
@@ -2,11 +2,11 @@
 
 import pathlib
 import argparse
-from datetime import datetime, timezone
-from two_plot import build_outlook
 from datetime import datetime, timezone, timedelta
+from two_plot import build_outlook
 from facebook_poster import post_to_facebook
 from gtwo_fetcher import download_gtwo_shapefile
+from two_data import download_gtwo_zip, parse_issue_time_from_xml
 import matplotlib.pyplot as plt
 import platform
 import shutil
@@ -28,8 +28,8 @@ def main():
                         help="Basin code: AL (Atlantic) or EP (Eastern Pacific). If omitted, both run.")
     parser.add_argument("--outdir", type=pathlib.Path, default=pathlib.Path("output"),
                         help="Directory to save output PNGs.")
-    parser.add_argument("--timestamp", default=datetime.now(timezone.utc).isoformat(),
-                        help="UTC timestamp (ISO format) to use in filenames.")
+    parser.add_argument("--timestamp", default=None,
+                        help="Override issuance timestamp in ISO format.")
     args = parser.parse_args()
 
     # Determine which basins to run
@@ -37,7 +37,11 @@ def main():
     outdir = args.outdir
     outdir.mkdir(exist_ok=True)
 
-    ts = datetime.fromisoformat(args.timestamp)
+    if args.timestamp:
+        ts = datetime.fromisoformat(args.timestamp)
+    else:
+        zip_path = download_gtwo_zip()
+        ts = parse_issue_time_from_xml(zip_path)
 
     for basin_tag, (label, prefix) in selected:
         try:

--- a/TWO_Script/two_data.py
+++ b/TWO_Script/two_data.py
@@ -75,7 +75,7 @@ def parse_issue_time_from_xml(zip_path: pathlib.Path) -> datetime.datetime:
 
 
 
-def get_two_gdfs(basin_tag: str, data_dir="data") -> tuple[gpd.GeoDataFrame, datetime.datetime]:
+def get_two_gdfs(basin_tag: str, data_dir="data") -> gpd.GeoDataFrame:
     import geopandas as gpd
     import pathlib
     import datetime
@@ -92,8 +92,6 @@ def get_two_gdfs(basin_tag: str, data_dir="data") -> tuple[gpd.GeoDataFrame, dat
 
     gdf = gdf[gdf["BASIN"].str.contains(basin_tag, case=False, na=False)].copy()
 
-    zip_path = download_gtwo_zip()
-    issue_dt = parse_issue_time_from_xml(zip_path)
 
     gdf["PROB2DAY"] = gdf["RISK2DAY"].str.title()
     gdf["PROB7DAY"] = gdf["RISK7DAY"].str.title()
@@ -103,7 +101,7 @@ def get_two_gdfs(basin_tag: str, data_dir="data") -> tuple[gpd.GeoDataFrame, dat
         gdf["PROB7DAY"].isin(["Low", "Medium", "High"])
     ]
 
-    return gdf, issue_dt
+    return gdf
 
 
 

--- a/TWO_Script/two_plot.py
+++ b/TWO_Script/two_plot.py
@@ -17,7 +17,8 @@ def build_outlook(basin: str, label: str, prefix: str,
         """Main function to build and save the tropical weather outlook map for one basin."""
         tag = "Atlantic" if basin == "AL" else "Pacific"
 
-        two, issue_dt = get_two_gdfs(tag)
+        two = get_two_gdfs(tag)
+        issue_dt = timestamp
         points = get_points(tag)
         lines  = get_lines(tag)
 


### PR DESCRIPTION
## Summary
- read issue timestamp from GTWO XML in `main.py`
- update `get_two_gdfs` to only return the dataframe
- pass the XML timestamp into `build_outlook`
- remove redundant timestamp parsing in plotting logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686930724b34832ba0bcbc5886fef902